### PR TITLE
style(RecipePanel): adjust layout, spacing, and sizing for better visual balance

### DIFF
--- a/frontend/src/components/bitcraft/items.tsx
+++ b/frontend/src/components/bitcraft/items.tsx
@@ -234,26 +234,30 @@ export const ItemListComponent: Component<ItemListComponentProps> = (props) => {
 
     return (
         <HoverCard>
-            <HoverCardTrigger class="rounded border-accent-foreground border-l-1 border-r-1 mx-1">
+            <HoverCardTrigger class="rounded-lg border border-border px-3 py-2 mx-1 flex flex-col items-center gap-1 bg-muted/10 shadow-sm">
                 <Show when={props.probability}>
-                    <div class="text-center">
-                        <ProbabilityIndicator probability={props.probability!} chances={props.chances}/>
+                    <div class="text-sm font-semibold text-foreground text-center">
+                        <ProbabilityIndicator probability={props.probability!} chances={props.chances} />
                     </div>
                 </Show>
-                <ItemStackArrayComponent stackProps={averages}/>
+                <ItemStackArrayComponent stackProps={averages} />
                 <Show when={props.showTip}>
-                    <div class="text-center text-muted-foreground underline decoration-1 decoration-dashed"
-                         onclick={() =>
-                             typeof props.probability === 'number' && props.chances && fullNode.toggle()
-                         }
+                    <button
+                        type="button"
+                        title="Toggle between average per output and full yield"
+                        class="text-xs text-muted-foreground underline underline-offset-2 decoration-muted-foreground/50 hover:decoration-muted-foreground/90 transition-colors text-center"
+                        onclick={() =>
+                            typeof props.probability === 'number' && props.chances && fullNode.toggle()
+                        }
                     >
                         {`(avg. / ${fullNode.useFullNode() ? "full yield" : "output"})`}
-                    </div>
+                    </button>
                 </Show>
             </HoverCardTrigger>
             <HoverCardContent class="w-auto min-w-64">
-                <div class="grid grid-flow-row grid-cols-2 justify-items-center overflow-y-auto max-h-[50vh]">
-                    <p class="text-center mb-2 col-span-2">Weighted List</p>
+                <div class="grid grid-flow-row grid-cols-2 justify-items-center max-h-[50vh] overflow-y-auto">
+                    <p class="text-center mb-2 col-span-2 text-sm text-muted-foreground">Weighted List</p>
+
                     <Show when={props.original}>
                         <div class="col-span-2 justify-self-center">
                             <ItemStackIcon
@@ -262,14 +266,16 @@ export const ItemListComponent: Component<ItemListComponentProps> = (props) => {
                             />
                         </div>
                     </Show>
-                    <div>Weight</div>
-                    <div>Items</div>
+
+                    <div class="text-xs font-semibold text-muted-foreground">Weight</div>
+                    <div class="text-xs font-semibold text-muted-foreground">Items</div>
+
                     <For each={possibilities}>
                         {(poss) => (
                             <>
-                                <Separator class="my-2 col-span-2 border-muted-foreground"/>
-                                <div class="place-self-center">{fixFloat(poss.probability, 3)}</div>
-                                <ItemStackArrayComponent stacks={() => poss.items}/>
+                                <Separator class="my-2 col-span-2 border-muted" />
+                                <div class="place-self-center text-sm">{fixFloat(poss.probability, 3)}</div>
+                                <ItemStackArrayComponent stacks={() => poss.items} />
                             </>
                         )}
                     </For>

--- a/frontend/src/components/bitcraft/items.tsx
+++ b/frontend/src/components/bitcraft/items.tsx
@@ -234,7 +234,7 @@ export const ItemListComponent: Component<ItemListComponentProps> = (props) => {
 
     return (
         <HoverCard>
-            <HoverCardTrigger class="rounded-lg border border-border px-3 py-2 mx-1 flex flex-col items-center gap-1 bg-muted/10 shadow-sm">
+            <HoverCardTrigger class="px-3 py-2 mx-1 flex flex-col items-center gap-1">
                 <Show when={props.probability}>
                     <div class="text-sm font-semibold text-foreground text-center">
                         <ProbabilityIndicator probability={props.probability!} chances={props.chances} />

--- a/frontend/src/components/details/buildingdesc-details.tsx
+++ b/frontend/src/components/details/buildingdesc-details.tsx
@@ -40,28 +40,29 @@ type RecipePanelProps<T> = {
 
 function RecipePanel<T>(props: RecipePanelProps<T>) {
     return (
-        <TabsContent class="mt-8" value={props.tabValue}>
-            <div class="flex flex-col min-w-1/2 justify-center">
-                <div class="grid grid-flow-col grid-rows-1 justify-center">
+        <TabsContent value={props.tabValue} class="animate-none">
+            <div class="flex flex-col items-center w-full  mx-auto gap-4 px-2 md:px-4">
+                <div class="grid grid-flow-col auto-cols-auto justify-center gap-2">
                     {props.getInputs(props.recipe)}
                 </div>
-                <div class="flex flex-row justify-center">
-                    <IconDown class="w-8 h-8 my-2"/>
+                <IconDown class="w-6 h-6 text-muted-foreground" />
+                <div class="grid grid-flow-col auto-cols-auto justify-center gap-2">
+                    {props.getOutputs(props.recipe)}
                 </div>
-                <div class="grid grid-flow-col grid-rows-1 justify-center">
-                    {props.getOutputs!(props.recipe)}
-                </div>
-                <div class="flex flex-col items-center mt-4">
+                <div class="grid w-full max-w-md gap-1">
                     <For each={props.getStatlines(props.recipe)}>
-                        {pair => <div class="flex flex-row w-full max-w-100">
-                            <div class="text-nowrap mr-2">{pair[0]}</div>
-                            <div class="dots-before flex flex-1 text-nowrap">{pair[1]}</div>
-                        </div>}
+                        {([label, value]) => (
+                            <div class="flex justify-between items-center border-b border-muted py-0.5 px-1 text-sm">
+                                <div class="text-muted-foreground">{label}</div>
+                                <div class="font-medium text-right">{value}</div>
+                            </div>
+                        )}
                     </For>
                 </div>
+
             </div>
         </TabsContent>
-    )
+    );
 }
 
 type RecipesPanelProps = {

--- a/frontend/src/components/details/itemdesc-details.tsx
+++ b/frontend/src/components/details/itemdesc-details.tsx
@@ -157,36 +157,44 @@ type RecipePanelProps<T> = {
 
 function RecipePanel<T>(props: RecipePanelProps<T>) {
     return (
-        <TabsContent class="mt-8" value={props.tabValue}>
-            <div class="flex flex-col min-w-1/2 justify-center">
-                <div class="grid grid-flow-col grid-rows-1 justify-center">
+        <TabsContent value={props.tabValue} class="animate-none">
+            <div class="flex flex-col items-center w-full mx-auto gap-3 px-2 md:px-4 max-w-[1100px]">
+                <div class="grid grid-flow-col auto-cols-auto justify-center gap-2">
                     {props.getInputs(props.recipe)}
                 </div>
-                <div class="flex flex-row justify-center">
-                    <IconDown class="w-8 h-8 my-2"/>
-                </div>
-                <div class="grid grid-flow-col grid-rows-1 justify-center">
-                    <Show when={props.getOutputs}
-                          fallback={
-                              <For each={props.getOutputStacks!(props.recipe)} fallback={"No Outputs"}>
-                                  {stack => expandStack(stack, props.maskedProbabilities, props.chances)}
-                              </For>
-                          }
+                <IconDown class="w-6 h-6 text-muted-foreground" />
+                <div class="grid grid-flow-col auto-cols-auto justify-center gap-2">
+                    <Show
+                        when={props.getOutputs}
+                        fallback={
+                            <For
+                                each={props.getOutputStacks?.(props.recipe)}
+                                fallback={<div class="col-span-full text-center text-muted-foreground">No Outputs</div>}
+                            >
+                                {(stack) => (
+                                    <div class="rounded-xl border border-border bg-muted/30 px-3 py-4 min-w-[80px] min-h-[80px] flex flex-col items-center justify-center text-center shadow-sm">
+                                        {expandStack(stack, props.maskedProbabilities, props.chances)}
+                                    </div>
+                                )}
+                            </For>
+                        }
                     >
                         {props.getOutputs!(props.recipe)}
                     </Show>
                 </div>
-                <div class="flex flex-col items-center mt-4">
+                <div class="grid w-full max-w-md gap-1">
                     <For each={props.getStatlines(props.recipe)}>
-                        {pair => <div class="flex flex-row w-full max-w-100">
-                            <div class="text-nowrap mr-2">{pair[0]}</div>
-                            <div class="dots-before flex flex-1 text-nowrap">{pair[1]}</div>
-                        </div>}
+                        {([label, value]) => (
+                            <div class="flex justify-between items-center border-b border-muted py-0.5 px-1 text-sm">
+                                <div class="text-muted-foreground">{label}</div>
+                                <div class="font-medium text-right">{value}</div>
+                            </div>
+                        )}
                     </For>
                 </div>
             </div>
         </TabsContent>
-    )
+    );
 }
 
 type RecipesPanelProps = {

--- a/frontend/src/components/details/itemdesc-details.tsx
+++ b/frontend/src/components/details/itemdesc-details.tsx
@@ -167,16 +167,18 @@ function RecipePanel<T>(props: RecipePanelProps<T>) {
                     <Show
                         when={props.getOutputs}
                         fallback={
-                            <For
-                                each={props.getOutputStacks?.(props.recipe)}
-                                fallback={<div class="col-span-full text-center text-muted-foreground">No Outputs</div>}
-                            >
-                                {(stack) => (
-                                    <div class="rounded-xl border border-border bg-muted/30 px-3 py-4 min-w-[80px] max-w-[200px] w-full overflow-x-auto flex-shrink-0 flex flex-col items-center justify-center text-center shadow-sm">
-                                        {expandStack(stack, props.maskedProbabilities, props.chances)}
-                                    </div>
-                                )}
-                            </For>
+                            <div class="flex overflow-x-auto gap-2 px-2  min-w-[80px] max-w-[200px]">
+                                <For
+                                    each={props.getOutputStacks?.(props.recipe)}
+                                    fallback={<div class="col-span-full text-center text-muted-foreground">No Outputs</div>}
+                                >
+                                    {(stack) => (
+                                        <div class="flex-shrink-0 rounded-xl border bg-muted/30 px-3 py-4 flex flex-col items-center text-center text-xs gap-1">
+                                            {expandStack(stack, props.maskedProbabilities, props.chances)}
+                                        </div>
+                                    )}
+                                </For>
+                            </div>
                         }
                     >
                         {props.getOutputs!(props.recipe)}

--- a/frontend/src/components/details/itemdesc-details.tsx
+++ b/frontend/src/components/details/itemdesc-details.tsx
@@ -159,7 +159,7 @@ function RecipePanel<T>(props: RecipePanelProps<T>) {
     return (
         <TabsContent value={props.tabValue} class="animate-none">
             <div class="flex flex-col items-center w-full mx-auto gap-3 px-2 md:px-4 max-w-[1100px]">
-                <div class="grid grid-flow-col auto-cols-auto justify-center gap-2">
+                <div class="grid grid-flow-col auto-cols-auto justify-center gap-2 mt-4">
                     {props.getInputs(props.recipe)}
                 </div>
                 <IconDown class="w-6 h-6 text-muted-foreground" />
@@ -167,18 +167,26 @@ function RecipePanel<T>(props: RecipePanelProps<T>) {
                     <Show
                         when={props.getOutputs}
                         fallback={
-                            <div class="flex overflow-x-auto gap-2 px-2  min-w-[80px] max-w-[200px]">
-                                <For
-                                    each={props.getOutputStacks?.(props.recipe)}
-                                    fallback={<div class="col-span-full text-center text-muted-foreground">No Outputs</div>}
+                            <div class="w-full rounded-xl border border-border bg-muted/30 px-2 py-3 overflow-hidden">
+                                <div
+                                    class="flex gap-2 overflow-x-auto"
+                                    style="scrollbar-width: thin; scrollbar-gutter: stable"
                                 >
-                                    {(stack) => (
-                                        <div class="flex-shrink-0 rounded-xl border bg-muted/30 px-3 py-4 flex flex-col items-center text-center text-xs gap-1">
-                                            {expandStack(stack, props.maskedProbabilities, props.chances)}
-                                        </div>
-                                    )}
-                                </For>
+                                    <For
+                                        each={props.getOutputStacks?.(props.recipe)}
+                                        fallback={<div class="col-span-full text-center text-muted-foreground">No Outputs</div>}
+                                    >
+                                        {(stack) => (
+                                            <div
+                                                class="flex-shrink-0 min-w-[80px] max-w-[200px] rounded-xl border bg-muted/30 px-3 py-4 flex flex-1/2 items-center text-center text-xs gap-1"
+                                            >
+                                                {expandStack(stack, props.maskedProbabilities, props.chances)}
+                                            </div>
+                                        )}
+                                    </For>
+                                </div>
                             </div>
+
                         }
                     >
                         {props.getOutputs!(props.recipe)}

--- a/frontend/src/components/details/itemdesc-details.tsx
+++ b/frontend/src/components/details/itemdesc-details.tsx
@@ -172,7 +172,7 @@ function RecipePanel<T>(props: RecipePanelProps<T>) {
                                 fallback={<div class="col-span-full text-center text-muted-foreground">No Outputs</div>}
                             >
                                 {(stack) => (
-                                    <div class="rounded-xl border border-border bg-muted/30 px-3 py-4 min-w-[80px] min-h-[80px] flex flex-col items-center justify-center text-center shadow-sm">
+                                    <div class="rounded-xl border border-border bg-muted/30 px-3 py-4 min-w-[80px] max-w-[200px] w-full overflow-x-auto flex-shrink-0 flex flex-col items-center justify-center text-center shadow-sm">
                                         {expandStack(stack, props.maskedProbabilities, props.chances)}
                                     </div>
                                 )}

--- a/frontend/src/components/details/resourcedesc-details.tsx
+++ b/frontend/src/components/details/resourcedesc-details.tsx
@@ -37,31 +37,38 @@ type RecipePanelProps<T> = {
 
 function RecipePanel<T>(props: RecipePanelProps<T>) {
     return (
-        <TabsContent class="mt-8" value={props.tabValue}>
-            <div class="flex flex-col min-w-1/2 justify-center">
-                <div class="grid grid-flow-col grid-rows-1 justify-center">
+        <TabsContent value={props.tabValue} class="animate-none">
+            <div class="flex flex-col items-center w-full  mx-auto gap-3 px-2 md:px-4">
+                <div class="grid grid-flow-col auto-cols-auto justify-center gap-2">
                     {props.getInputs(props.recipe)}
                 </div>
-                <div class="flex flex-row justify-center">
-                    <IconDown class="w-8 h-8 my-2"/>
-                </div>
-                <div class="grid grid-flow-col grid-rows-1 justify-center">
-                    <For each={props.getOutputStacks!(props.recipe)} fallback={"No Outputs"}>
-                        {stack => expandStack(stack, props.maskedProbabilities, props.chances)}
+                <IconDown class="w-6 h-6 text-muted-foreground" />
+                <div class="grid grid-flow-col auto-cols-auto justify-center gap-2">
+                    <For each={props.getOutputStacks?.(props.recipe)} fallback={
+                        <div class="col-span-full text-center text-muted-foreground">No Outputs</div>
+                    }>
+                        {(stack) => (
+                            <div class="rounded-xl border border-border bg-muted/30 px-3 py-4 min-w-[80px] min-h-[80px] flex flex-col items-center justify-center text-center shadow-sm">
+                                {expandStack(stack, props.maskedProbabilities, props.chances)}
+                            </div>
+                        )}
                     </For>
                 </div>
-                <div class="flex flex-col items-center mt-4">
+                <div class="grid w-full max-w-md gap-2">
                     <For each={props.getStatlines(props.recipe)}>
-                        {pair => <div class="flex flex-row w-full max-w-100">
-                            <div class="text-nowrap mr-2">{pair[0]}</div>
-                            <div class="dots-before flex flex-1 text-nowrap">{pair[1]}</div>
-                        </div>}
+                        {([label, value]) => (
+                            <div class="flex justify-between items-center border-b border-muted py-1 px-1">
+                                <div class="text-sm text-muted-foreground font-medium">{label}</div>
+                                <div class="text-sm font-semibold text-right">{value}</div>
+                            </div>
+                        )}
                     </For>
                 </div>
             </div>
         </TabsContent>
-    )
+    );
 }
+
 
 type RecipesPanelProps = {
     value: Accessor<Option>,
@@ -208,8 +215,8 @@ const RecipesCard: Component<ResourceCardProps> = (props) => {
     return (
         <Show when={usageOptions.length || acquireOptions.length}>
             <Card>
-                <CardContent class="mt-6">
-                    <Tabs class="w-full">
+                <CardContent class="mt-6 px-10">
+                    <Tabs class="w-full h-fit">
                         <TabsList class="grid grid-cols-2">
                             <TabsTrigger value="obtain" disabled={acquireOptions.length == 0}>Obtain</TabsTrigger>
                             <TabsTrigger value="use" disabled={usageOptions.length == 0}>Use</TabsTrigger>


### PR DESCRIPTION
This PR updates the RecipePanel layout to improve readability and spacing across input, output, and statline sections.

Changes include:
- Adjusted outer container width and padding for better centering
- Unified gap spacing between sections using `gap-2` and `gap-3`
- Output stack cards now use consistent border, padding, and size for clarity
- Statline layout made more compact with smaller font and cleaner alignment
- Removed transition animation from tab panel for a faster, cleaner experience

This is a visual-only PR with no functional logic changes.

Also, I'm a very junior dev still learning and really enjoying contributing to this project. Feedback is very welcome!
