### PR TITLE
Fix discarding precisions less than 3 places.

### DIFF
--- a/frontend/src/components/bitcraft/items.tsx
+++ b/frontend/src/components/bitcraft/items.tsx
@@ -157,7 +157,7 @@ export const ItemStackIcon: Component<ItemStackIconProps> = (props) => {
             </Show>
             <ItemIcon {...others} quantity={local.quantity}/>
             <Show when={text}>
-                <p>{text}</p>
+                <p class="px-1">{text}</p>
             </Show>
         </div>
     )

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -28,7 +28,7 @@ export function compareBasic(a: number, b: number) {
 }
 
 export function fixFloat(f: number, places: number = 3) {
-    return +f.toFixed(places);
+    return +f.toPrecision(places);
 }
 
 export function splitCamelCase(str: string) {


### PR DESCRIPTION
Mythic lusul pretending to be 0 chance.
Also force some padding since the numbers all ran into each other.